### PR TITLE
require all dependencies for catkin_simple packages by using

### DIFF
--- a/aslam_backend/CMakeLists.txt
+++ b/aslam_backend/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(aslam_backend)
 
 find_package(catkin_simple REQUIRED)
-catkin_simple()
+catkin_simple(ALL_DEPS_REQUIRED)
 
 find_package(Boost REQUIRED COMPONENTS system thread)
 

--- a/aslam_backend/package.xml
+++ b/aslam_backend/package.xml
@@ -18,8 +18,8 @@
   <build_depend>sm_eigen</build_depend>
   <build_depend>sm_property_tree</build_depend>
   <build_depend>suitesparse</build_depend>
-  <build_depend>TBB</build_depend>
   <build_depend>asl_cmake_modules</build_depend>
+  <build_depend>TBB</build_depend>
 
   <run_depend>sparse_block_matrix</run_depend>
   <run_depend>sm_boost</run_depend>
@@ -28,7 +28,7 @@
   <run_depend>sm_logging</run_depend>
   <run_depend>sm_property_tree</run_depend>
   <run_depend>eigen_catkin</run_depend>
-  <run_depend>TBB</run_depend>
   <run_depend>asl_cmake_modules</run_depend>
+  <run_depend>TBB</run_depend>
 
 </package>

--- a/aslam_backend_expressions/CMakeLists.txt
+++ b/aslam_backend_expressions/CMakeLists.txt
@@ -7,7 +7,7 @@ SET(CMAKE_CXX_FLAGS "-std=c++0x")
 
 find_package(catkin_simple REQUIRED)
 
-catkin_simple()
+catkin_simple(ALL_DEPS_REQUIRED)
 
 include_directories(${EIGEN_INCLUDE_DIRS})
 

--- a/aslam_backend_expressions/package.xml
+++ b/aslam_backend_expressions/package.xml
@@ -15,7 +15,7 @@
   <build_depend>sm_boost</build_depend>
   <build_depend>sm_random</build_depend>
   <build_depend>sm_kinematics</build_depend>
-  <build_depend>eigen</build_depend>
+  <build_depend>eigen_catkin</build_depend>
   <build_depend>sparse_block_matrix</build_depend>
   <build_depend>suitesparse</build_depend>
   <build_depend>sm_timing</build_depend>


### PR DESCRIPTION
catkin_simple(ALL_DEPS_REQUIRED)

Interestingly the order of dependencies can matter with this option. 
I had to move TBB below asl_cmake_modules.
