### PR TITLE
started a generic KinematicChain toolbox to calculate e.g. global linear...

### DIFF
--- a/aslam_backend_expressions/CMakeLists.txt
+++ b/aslam_backend_expressions/CMakeLists.txt
@@ -50,6 +50,8 @@ cs_add_library(${PROJECT_NAME}
   src/L1Regularizer.cpp
 
   src/MapTransformation.cpp
+
+  src/KinematicChain.cpp
   )
 
 target_link_libraries(${PROJECT_NAME} ${Boost_LIBRARIES})

--- a/aslam_backend_expressions/CMakeLists.txt
+++ b/aslam_backend_expressions/CMakeLists.txt
@@ -79,6 +79,7 @@ catkin_add_gtest(${PROJECT_NAME}_test
   test/ErrorTest_Euclidean.cpp
   test/ErrorTest_L1Regularizer.cpp
   test/VectorExpressionTest.cpp 
+  test/KinematicChain.cpp 
   )
 
 target_link_libraries(${PROJECT_NAME}_test ${PROJECT_NAME})

--- a/aslam_backend_expressions/include/aslam/backend/KinematicChain.hpp
+++ b/aslam_backend_expressions/include/aslam/backend/KinematicChain.hpp
@@ -32,17 +32,15 @@ class CoordinateFrame {
   CoordinateFrame (boost::shared_ptr<const CoordinateFrame> parent, RotationExpression R_P_L = RotationExpression(), EuclideanExpression p = EuclideanExpression(), EuclideanExpression omega = EuclideanExpression(), EuclideanExpression v = EuclideanExpression(), EuclideanExpression alpha = EuclideanExpression(), EuclideanExpression a = EuclideanExpression())
     : pp(parent), R_P_L(R_P_L), p(p), v(v), a(a), omega(omega), alpha(alpha)
   {
+    if(!parent){
+      initGlobalsWithoutParent();
+    }
   }
 
   CoordinateFrame (RotationExpression R_P_L, EuclideanExpression p = EuclideanExpression(), EuclideanExpression omega = EuclideanExpression(), EuclideanExpression v = EuclideanExpression(), EuclideanExpression alpha = EuclideanExpression(), EuclideanExpression a = EuclideanExpression())
     : pp(nullptr), R_P_L(R_P_L), p(p), v(v), a(a), omega(omega), alpha(alpha)
   {
-    R_G_L = R_P_L;
-    pG = p;
-    omegaG = omega;
-    vG = v;
-    alphaG = alpha;
-    aG = a;
+    initGlobalsWithoutParent();
   }
 
   const boost::shared_ptr<const CoordinateFrame> getParent() {
@@ -111,6 +109,8 @@ class CoordinateFrame {
     return alpha;
   }
  private:
+  void initGlobalsWithoutParent();
+
   boost::shared_ptr<const CoordinateFrame> pp;
   mutable RotationExpression R_G_L;
   RotationExpression R_P_L; // converting coordinates from to this to global or parent frame

--- a/aslam_backend_expressions/include/aslam/backend/KinematicChain.hpp
+++ b/aslam_backend_expressions/include/aslam/backend/KinematicChain.hpp
@@ -1,0 +1,124 @@
+/*
+ * KinematicChain.hpp
+ *
+ *  Created on: Oct 7, 2014
+ *      Author: hannes
+ */
+
+#ifndef KINEMATICCHAIN_HPP_
+#define KINEMATICCHAIN_HPP_
+
+#include <sm/boost/null_deleter.hpp>
+#include "EuclideanExpression.hpp"
+#include "RotationExpression.hpp"
+#include "ScalarExpression.hpp"
+
+namespace aslam {
+namespace backend {
+
+class CoordinateFrame {
+ public:
+  CoordinateFrame() : pp(nullptr) {};
+  CoordinateFrame(const CoordinateFrame &) = default;
+  CoordinateFrame(CoordinateFrame &&) = default;
+
+  CoordinateFrame & operator = (const CoordinateFrame &) = default;
+  CoordinateFrame & operator = (CoordinateFrame &&) = default;
+
+  CoordinateFrame (const CoordinateFrame & parent, RotationExpression R_P_L = RotationExpression(), EuclideanExpression p = EuclideanExpression(), EuclideanExpression omega = EuclideanExpression(), EuclideanExpression v = EuclideanExpression(), EuclideanExpression alpha = EuclideanExpression(), EuclideanExpression a = EuclideanExpression())
+    : pp(&parent, sm::null_deleter()), R_P_L(R_P_L), p(p), v(v), a(a), omega(omega), alpha(alpha)
+  {
+  }
+  CoordinateFrame (boost::shared_ptr<const CoordinateFrame> parent, RotationExpression R_P_L = RotationExpression(), EuclideanExpression p = EuclideanExpression(), EuclideanExpression omega = EuclideanExpression(), EuclideanExpression v = EuclideanExpression(), EuclideanExpression alpha = EuclideanExpression(), EuclideanExpression a = EuclideanExpression())
+    : pp(parent), R_P_L(R_P_L), p(p), v(v), a(a), omega(omega), alpha(alpha)
+  {
+  }
+
+  CoordinateFrame (RotationExpression R_P_L, EuclideanExpression p = EuclideanExpression(), EuclideanExpression omega = EuclideanExpression(), EuclideanExpression v = EuclideanExpression(), EuclideanExpression alpha = EuclideanExpression(), EuclideanExpression a = EuclideanExpression())
+    : pp(nullptr), R_P_L(R_P_L), p(p), v(v), a(a), omega(omega), alpha(alpha)
+  {
+    R_G_L = R_P_L;
+    pG = p;
+    omegaG = omega;
+    vG = v;
+    alphaG = alpha;
+    aG = a;
+  }
+
+  const boost::shared_ptr<const CoordinateFrame> getParent() {
+    return pp;
+  }
+
+  const RotationExpression & getR_G_L() const {
+    if(pp && R_G_L.isEmpty()){
+      R_G_L = pp->getR_G_L() * R_P_L;
+    }
+    return R_G_L;
+  }
+
+  const EuclideanExpression & getOmegaG() const {
+    if(pp && omegaG.isEmpty()){
+      omegaG = pp->getOmegaG() + pp->getR_G_L() * omega;
+    }
+    return omegaG;
+  }
+
+  const EuclideanExpression & getAlphaG() const {
+    if(pp && alphaG.isEmpty()){
+      alphaG = pp->getAlphaG() + pp->getOmegaG().cross(pp->getR_G_L() * omega) + pp->getR_G_L() * alpha;
+    }
+    return alphaG;
+  }
+
+
+  const EuclideanExpression & getPG() const {
+    if(pp && pG.isEmpty()){
+      pG = pp->getPG() + pp->getR_G_L() * p;
+    }
+    return pG;
+  }
+
+  const EuclideanExpression & getVG() const {
+    if(pp && vG.isEmpty()){
+      vG = pp->getVG() + pp->getR_G_L() * v + pp->getOmegaG().cross(pp->getR_G_L() * p); //TODO have a caching variable for (pp->getR_G_L() * p)!
+    }
+    return vG;
+  }
+
+  const EuclideanExpression & getAG() const {
+    if(pp && aG.isEmpty()){
+      aG = pp->getAG() + pp->getR_G_L() * a + pp->getOmegaG().cross(pp->getR_G_L() * v) + pp->getAlphaG().cross(pp->getR_G_L() * p) + pp->getOmegaG().cross(pp->getOmegaG().cross(pp->getR_G_L() * p));
+    }
+    return aG;
+  }
+
+  const RotationExpression & getR_P_L() const {
+    return R_P_L;
+  }
+  const EuclideanExpression & getPP() const {
+    return p;
+  }
+  const EuclideanExpression & getBP() const {
+    return v;
+  }
+  const EuclideanExpression & getAP() const {
+    return a;
+  }
+  const EuclideanExpression & getOmegaP() const {
+    return omega;
+  }
+  const EuclideanExpression & getAlphaP() const {
+    return alpha;
+  }
+ private:
+  boost::shared_ptr<const CoordinateFrame> pp;
+  mutable RotationExpression R_G_L;
+  RotationExpression R_P_L; // converting coordinates from to this to global or parent frame
+  EuclideanExpression p, v, a, omega, alpha;
+  mutable EuclideanExpression pG, vG, aG, omegaG, alphaG;
+};
+
+} // namespace backend
+} // namespace aslam
+
+#endif /* KINEMATICCHAIN_HPP_ */

--- a/aslam_backend_expressions/src/KinematicChain.cpp
+++ b/aslam_backend_expressions/src/KinematicChain.cpp
@@ -1,0 +1,16 @@
+#include <aslam/backend/KinematicChain.hpp>
+
+namespace aslam {
+namespace backend {
+
+void aslam::backend::CoordinateFrame::initGlobalsWithoutParent() {
+  R_G_L = R_P_L;
+  pG = p;
+  omegaG = omega;
+  vG = v;
+  alphaG = alpha;
+  aG = a;
+}
+
+}  // namespace backend
+}  // namespace aslam

--- a/aslam_backend_expressions/test/KinematicChain.cpp
+++ b/aslam_backend_expressions/test/KinematicChain.cpp
@@ -1,0 +1,128 @@
+/** KinematicChain.cpp
+ *  Created on: Oct 7, 2014
+ *      Author: hannes
+ */
+
+#include <Eigen/Geometry>
+#include <sm/eigen/gtest.hpp>
+#include <sm/eigen/NumericalDiff.hpp>
+#include <aslam/backend/KinematicChain.hpp>
+#include <aslam/backend/EuclideanPoint.hpp>
+#include <aslam/backend/EuclideanExpression.hpp>
+#include <aslam/backend/test/ExpressionTests.hpp>
+
+
+using namespace aslam::backend;
+
+Eigen::Vector3d Zero = Eigen::Vector3d::Zero();
+Eigen::Matrix3d Identity = Eigen::Matrix3d::Identity();
+Eigen::Vector3d Ones = Eigen::Vector3d::Ones();
+Eigen::Matrix3d MinusIdentity = -Eigen::Matrix3d::Identity();
+Eigen::Vector3d X = Eigen::Vector3d::UnitX();
+Eigen::Vector3d Y = Eigen::Vector3d::UnitY();
+Eigen::Vector3d Z = Eigen::Vector3d::UnitZ();
+
+TEST(KinematicChainTestSuites, testTheoreticallyOneFrame) {
+  {
+    CoordinateFrame A = CoordinateFrame(RotationExpression());
+    std::string msg = "Testing all nothing.";
+
+    sm::eigen::assertEqual(A.getPG().toValue(), Zero, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getVG().toValue(), Zero, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getAG().toValue(), Zero, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getR_G_L().toRotationMatrix(), Identity, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getOmegaG().toValue(), Zero, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getAlphaG().toValue(), Zero, SM_SOURCE_FILE_POS, msg);
+  }
+  {
+    CoordinateFrame A(MinusIdentity, Ones, Ones, Ones, Ones, Ones);
+    std::string msg = "Testing all one.";
+
+    sm::eigen::assertEqual(A.getPG().toValue(), Ones, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getVG().toValue(), Ones, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getAG().toValue(), Ones, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getR_G_L().toRotationMatrix(), MinusIdentity, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getOmegaG().toValue(), Ones, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getAlphaG().toValue(), Ones, SM_SOURCE_FILE_POS, msg);
+  }
+}
+TEST(KinematicChainTestSuites, testTheoreticallyTwoFrames) {
+  {
+    CoordinateFrame B(Identity, Ones, Ones, Ones, Ones, Ones);
+    CoordinateFrame A(B, Identity, Ones, Ones, Ones, Ones, Ones);
+    std::string msg = "Testing all one.";
+
+    sm::eigen::assertEqual(A.getPG().toValue(), Ones * 2, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getVG().toValue(), Ones * 2, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getAG().toValue(), Ones * 2, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getR_G_L().toRotationMatrix(), Identity, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getOmegaG().toValue(), Ones * 2, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getAlphaG().toValue(), Ones * 2, SM_SOURCE_FILE_POS, msg);
+  }
+
+  {
+    CoordinateFrame B(MinusIdentity, Ones, Ones, Ones, Ones, Ones);
+    CoordinateFrame A(B, MinusIdentity, Ones, Ones, Ones, Ones, Ones);
+    std::string msg = "Testing all one or -Identity.";
+
+    sm::eigen::assertEqual(A.getPG().toValue(), Zero, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getVG().toValue(), Zero, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getAG().toValue(), Zero, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getR_G_L().toRotationMatrix(), Identity, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getOmegaG().toValue(), Zero, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getAlphaG().toValue(), Zero, SM_SOURCE_FILE_POS, msg);
+  }
+
+  {
+    CoordinateFrame B(Identity, Ones, X, Ones, Ones, Ones);
+    CoordinateFrame A(B, Identity, Y, Zero, Zero, Zero, Zero);
+    std::string msg = "Testing simple non trivial example";
+
+    sm::eigen::assertEqual(A.getPG().toValue(), Ones + Y, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getVG().toValue(), Ones + Z, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getAG().toValue(), Ones + Ones.cross(Y) + X.cross(X.cross(Y)), SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getR_G_L().toRotationMatrix(), Identity, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getOmegaG().toValue(), X, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(A.getAlphaG().toValue(), Ones, SM_SOURCE_FILE_POS, msg);
+  }
+
+  {
+    EuclideanPoint a_m_mrV(Eigen::Vector3d::Random());
+    EuclideanPoint t_m_riV(Eigen::Vector3d::Random());
+    EuclideanPoint w_m_mrV(Eigen::Vector3d::Random());
+    EuclideanPoint dw_m_mrV(Eigen::Vector3d::Random());
+    EuclideanExpression a_m_mr(&a_m_mrV);
+    EuclideanExpression t_m_ri(&t_m_riV);
+    EuclideanExpression w_m_mr(&w_m_mrV);
+    EuclideanExpression dw_m_mr(&dw_m_mrV);
+
+    CoordinateFrame M(Identity, X, w_m_mr, Y, dw_m_mr, a_m_mr);
+    CoordinateFrame I(M, MinusIdentity, t_m_ri);
+    std::string msg = "Testing robot - imu example";
+
+//    aG = pp->getR_G_L() * a + pp->getOmegaG().cross(pp->getR_G_L() * v) + pp->getAlphaG().cross(pp->getR_G_L() * p) + pp->getOmegaG().cross(pp->getOmegaG().cross(pp->getR_G_L() * p));
+
+    EuclideanExpression a_m_mi = a_m_mr + dw_m_mr.cross(t_m_ri) + w_m_mr.cross(w_m_mr.cross(t_m_ri));
+    sm::eigen::assertEqual(I.getPP().toValue(), t_m_ri.toValue(), SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(I.getAP().toValue(), Zero, SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(I.getOmegaG().toValue(), w_m_mr.toValue(), SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(M.getAG().toValue(), a_m_mr.toValue(), SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(M.getAlphaG().toValue(), dw_m_mr.toValue(), SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(I.getAlphaG().toValue(), dw_m_mr.toValue(), SM_SOURCE_FILE_POS, msg);
+    sm::eigen::assertEqual(I.getAG().toValue(), a_m_mi.toValue(), SM_SOURCE_FILE_POS, msg);
+
+    testExpression(I.getAG(), 4);
+    testExpression(a_m_mi, 4);
+
+    Eigen::MatrixXd m1 = evaluateJacobian(I.getAG(), 4, true);
+    Eigen::MatrixXd m2 = evaluateJacobian(a_m_mi, 4, false);
+    sm::eigen::assertEqual(m1, m2, SM_SOURCE_FILE_POS, msg);
+  }
+
+
+  //TODO add further test including random
+  // CoordinateFrame (R_L_P, p, omega, v, alpha, a)
+//  CoordinateFrame
+//    C, B(C), A(B);
+
+}


### PR DESCRIPTION
... acceleration based on known relative velocities and accelerations (linear and angular) for a chain of coordinate frames

This is a tool for retrieving expressions for linear and angular derivatives and poses between start and end of a chain of frames (e.g. A, B, C) for which the corresponding relative information is provided as expressions (so from one frame to its former, means C to B, B to A, A to "global".

@furgalep, do you think this is worth being integrated? 
If so, how would you do the naming scheme? 

Is KinematicChain a good idea for a name?

How would you abbreviate (as part of identifiers) the roles of from current (this) frame to the parent (currently P_L, L for local) frame or to the "global" frame (currently G_L) and w.r.t global frame (currently G) or w.r.t. parent frame (currently P)?

Or would you do all differently :) ? 
