### PR TITLE
Made operator << (std::ostream &, const FixedPointNumber &) templated…

### DIFF
--- a/aslam_backend_expressions/include/aslam/backend/FixedPointNumber.hpp
+++ b/aslam_backend_expressions/include/aslam/backend/FixedPointNumber.hpp
@@ -122,6 +122,7 @@ class FixedPointNumber{
     return _p != other._p;
   }
 
+  template <typename = void>
   friend std::ostream & operator << (std::ostream & o, const FixedPointNumber & v){
     o << "[" << v.getNumerator() << " / " << v.getDenominator() << "]";
     return o;


### PR DESCRIPTION
… such that it does not require ostream to be known in parsing phase
