### PR TITLE
Add burn-in flag to sampler

### DIFF
--- a/aslam_backend/include/aslam/backend/SamplerBase.hpp
+++ b/aslam_backend/include/aslam/backend/SamplerBase.hpp
@@ -93,6 +93,11 @@ class SamplerBase {
   /// \brief Set smoothing factor for exponential moving average of acceptance probabilities
   void setWeightedMeanSmoothingFactor(const double alpha);
 
+  /// \brief Set the burn-in phase state of the sampler
+  void setIsBurnIn(const bool isBurnIn) { _isBurnIn = isBurnIn; }
+  /// \brief Whether or not the sampler is in burn-in phase
+  bool isBurnIn() const { return _isBurnIn; }
+
  protected:
   /// \brief Evaluate the current negative log density
   double evaluateNegativeLogDensity(const size_t nThreads = 1) const;
@@ -113,6 +118,9 @@ class SamplerBase {
 
   bool _isLastSampleAccepted = false; /// \brief Was the sample in the last iteration accepted
   bool _forceRecomputationNegLogDensity = true; /// \brief Should density information definitely be recomputed in the next step
+
+  bool _isBurnIn = false; /// \brief Whether or not the sampler is in burn-in phase
+
 };
 
 }

--- a/aslam_backend/src/SamplerHybridMcmc.cpp
+++ b/aslam_backend/src/SamplerHybridMcmc.cpp
@@ -119,11 +119,13 @@ void SamplerHybridMcmc::step(bool& accepted, double& acceptanceProbability) {
   using namespace Eigen;
 
   // Adapt step length
-  if (statistics().getWeightedMeanAcceptanceProbability() > _options.targetAcceptanceRate)
-    _stepLength *= _options.incFactorLeapFrogStepSize;
-  else
-    _stepLength *= _options.decFactorLeapFrogStepSize;
-  _stepLength = max(min(_stepLength, _options.maxLeapFrogStepSize), _options.minLeapFrogStepSize); // clip
+  if (isBurnIn()) {
+    if (statistics().getWeightedMeanAcceptanceProbability() > _options.targetAcceptanceRate)
+      _stepLength *= _options.incFactorLeapFrogStepSize;
+    else
+      _stepLength *= _options.decFactorLeapFrogStepSize;
+    _stepLength = max(min(_stepLength, _options.maxLeapFrogStepSize), _options.minLeapFrogStepSize); // clip
+  }
 
   SM_FINEST_STREAM_NAMED("sampling", "Current leap frog step size is " << _stepLength << ".");
 

--- a/aslam_backend_python/src/Sampler.cpp
+++ b/aslam_backend_python/src/Sampler.cpp
@@ -46,6 +46,7 @@ void exportSampler()
       .def("checkNegativeLogDensitySetup", &SamplerBase::checkNegativeLogDensitySetup)
       .def("setWeightedMeanSmoothingFactor", &SamplerBase::setWeightedMeanSmoothingFactor)
       .add_property("statistics", make_function(&SamplerBase::statistics, return_internal_reference<>()))
+      .add_property("isBurnIn", &SamplerBase::setIsBurnIn, &SamplerBase::isBurnIn)
   ;
   implicitly_convertible< boost::shared_ptr<SamplerBase>, boost::shared_ptr<const SamplerBase> >();
 


### PR DESCRIPTION
For instance, the leapfrog transition kernel should not be modified during sampling.
The sampler should be informed whether it is in burn-in phase, to restrict kernel adaptations to this phase.
