### PR TITLE
Introduced LinearSystemSolver::acceptConstantErrorTerms

### DIFF
--- a/aslam_backend/include/aslam/backend/CompressedColumnMatrix.hpp
+++ b/aslam_backend/include/aslam/backend/CompressedColumnMatrix.hpp
@@ -146,6 +146,13 @@ namespace aslam {
       /// Initializes the matrix from a cholmod_sparse matrix
       void fromCholmodSparse(const cholmod_sparse* cs);
 
+      bool isAcceptConstantErrorTerms() const {
+        return _acceptConstantErrorTerms;
+      }
+
+      void setAcceptConstantErrorTerms(bool acceptConstantErrorTerms) {
+        _acceptConstantErrorTerms = acceptConstantErrorTerms;
+      }
     private:
       void checkMatrixDbg();
 
@@ -156,6 +163,10 @@ namespace aslam {
       std::vector<index_t> _col_ptr;
 
       bool _hasDiagonalAppended;
+
+      /// \brief If enabled the system builder must not complain about constant error terms (:= not depending on any active design variable)
+      bool _acceptConstantErrorTerms = false;
+
       // Keep one of these guys around to make cs views.
       cholmod_sparse _cholmodSparse;
 

--- a/aslam_backend/include/aslam/backend/LinearSystemSolver.hpp
+++ b/aslam_backend/include/aslam/backend/LinearSystemSolver.hpp
@@ -72,6 +72,11 @@ namespace aslam {
       // helper function for dog leg implementation / steepest descent solution
       virtual double rhsJtJrhs() = 0;
 
+      /// \brief If enabled the system builder must not throw on constant error terms (:= not depending on any active design variable)
+      bool isAcceptConstantErrorTerms() const {
+        return _acceptConstantErrorTerms;
+      }
+      void setAcceptConstantErrorTerms(bool acceptConstantErrorTerms);
     protected:
       /// \brief initialized the matrix structure for the problem with these error terms and errors.
       virtual void initMatrixStructureImplementation(const std::vector<DesignVariable*>& dvs, const std::vector<ErrorTerm*>& errors, bool useDiagonalConditioner) = 0;
@@ -85,6 +90,9 @@ namespace aslam {
 
       /// \brief a function to split a multi-threaded job across all error term indices.
       void setupThreadedJob(boost::function<void(size_t, size_t, size_t, bool)> job, size_t nThreads, bool useMEstimator);
+
+      /// \brief Event hook to handle new value for the acceptConstantErrorTerms property
+      virtual void handleNewAcceptConstantErrorTerms();
 
       /// \brief the vector of error terms.
       std::vector<ErrorTerm*> _errorTerms;
@@ -101,6 +109,9 @@ namespace aslam {
       /// \brief Should we use a diagonal conditioner
       bool _useDiagonalConditioner;
 
+      /// \brief If enabled the system builder must not complain about constant error terms (:= not depending on any active design variable)
+      bool _acceptConstantErrorTerms;
+
       /// \brief The diagonal conditioner
       Eigen::VectorXd _diagonalConditioner;
 
@@ -109,7 +120,6 @@ namespace aslam {
 
       /// \brief The number of columns in the Jacobian matrix
       size_t _JCols;
-
     };
 
   } // namespace backend

--- a/aslam_backend/include/aslam/backend/SparseCholeskyLinearSystemSolver.hpp
+++ b/aslam_backend/include/aslam/backend/SparseCholeskyLinearSystemSolver.hpp
@@ -38,6 +38,7 @@ namespace aslam {
     
     private:
       virtual void initMatrixStructureImplementation(const std::vector<DesignVariable*>& dvs, const std::vector<ErrorTerm*>& errors, bool useDiagonalConditioner);
+      virtual void handleNewAcceptConstantErrorTerms() override;
 
       CompressedColumnJacobianTransposeBuilder<int> _jacobianBuilder;
 

--- a/aslam_backend/include/aslam/backend/SparseQrLinearSystemSolver.hpp
+++ b/aslam_backend/include/aslam/backend/SparseQrLinearSystemSolver.hpp
@@ -59,6 +59,7 @@ namespace aslam {
 
     private:
       virtual void initMatrixStructureImplementation(const std::vector<DesignVariable*>& dvs, const std::vector<ErrorTerm*>& errors, bool useDiagonalConditioner);
+      virtual void handleNewAcceptConstantErrorTerms() override;
 
       CompressedColumnJacobianTransposeBuilder<index_t> _jacobianBuilder;
 

--- a/aslam_backend/include/aslam/backend/implementation/CompressedColumnMatrix.hpp
+++ b/aslam_backend/include/aslam/backend/implementation/CompressedColumnMatrix.hpp
@@ -249,8 +249,9 @@ namespace aslam {
           elementsPerColumn += dv->minimalDimensions();
         }
       }
-      //std::cout << "Elements per column: " << elementsPerColumn << ", rows: " << Jrows << std::endl;
-      SM_ASSERT_FALSE_DBG(Exception, activeDvs.empty(), "There are no active design variables associated with this error term.");
+      if(!_acceptConstantErrorTerms){
+        SM_ASSERT_FALSE(Exception, activeDvs.empty(), "There are no active design variables associated with this error term. Enable acceptConstantErrorTerms in your LinearSystemSolver if this is required.");
+      }
       // Sort the indices by block index.
       std::sort(activeDvs.begin(), activeDvs.end(), DesignVariable::BlockIndexOrdering());
       size_t startValueIndex = _row_ind.size();

--- a/aslam_backend/src/LinearSystemSolver.cpp
+++ b/aslam_backend/src/LinearSystemSolver.cpp
@@ -8,7 +8,10 @@
 namespace aslam {
   namespace backend {
 
-    LinearSystemSolver::LinearSystemSolver() {}
+    LinearSystemSolver::LinearSystemSolver() :
+      _acceptConstantErrorTerms(false)
+    {
+    }
     LinearSystemSolver::~LinearSystemSolver() {}
 
     void LinearSystemSolver::evaluateErrors(size_t threadId, size_t startIdx, size_t endIdx, bool useMEstimator)
@@ -152,6 +155,15 @@ namespace aslam {
       return _JCols;
     }
 
+    void LinearSystemSolver::setAcceptConstantErrorTerms(bool acceptConstantErrorTerms) {
+      if(this->_acceptConstantErrorTerms != acceptConstantErrorTerms){
+        this->_acceptConstantErrorTerms = acceptConstantErrorTerms;
+        handleNewAcceptConstantErrorTerms();
+      }
+    }
+
+    void LinearSystemSolver::handleNewAcceptConstantErrorTerms() {
+    }
 
   } // namespace backend
-} // namespace aslam
+}  // namespace aslam

--- a/aslam_backend/src/SparseCholeskyLinearSystemSolver.cpp
+++ b/aslam_backend/src/SparseCholeskyLinearSystemSolver.cpp
@@ -110,7 +110,9 @@ namespace aslam {
         return Jrhs.squaredNorm();
     }
       
-      
-
+    void SparseCholeskyLinearSystemSolver::handleNewAcceptConstantErrorTerms() {
+      _jacobianBuilder.J_transpose().setAcceptConstantErrorTerms(isAcceptConstantErrorTerms());
+    }
   } // namespace backend
-} // namespace aslam
+}  // namespace aslam
+

--- a/aslam_backend/src/SparseQrLinearSystemSolver.cpp
+++ b/aslam_backend/src/SparseQrLinearSystemSolver.cpp
@@ -190,7 +190,8 @@ namespace aslam {
         return Jrhs.squaredNorm();
     }
       
-      
-      
+    void SparseQrLinearSystemSolver::handleNewAcceptConstantErrorTerms() {
+      _jacobianBuilder.J_transpose().setAcceptConstantErrorTerms(isAcceptConstantErrorTerms());
+    }
   } // namespace backend
 } // namespace aslam

--- a/aslam_backend/test/LinearSolverTests.cpp
+++ b/aslam_backend/test/LinearSolverTests.cpp
@@ -137,3 +137,30 @@ TEST(LinearSolverTestSuite, testSparseQR)
             }*/
   }
 }
+
+class ConstZeroError : public ErrorTermFs<1> {
+ protected:
+  virtual double evaluateErrorImplementation() { return 0; }
+
+  virtual void evaluateJacobiansImplementation(JacobianContainer &) {}
+};
+
+TEST(LinearSolverTestSuite, testSparseQRAcceptConstantErrorTerms)
+{
+  using namespace aslam::backend;
+  std::vector<DesignVariable*> dvs;
+  std::vector<ErrorTerm*> errs;
+
+  buildSystem(1, 1, dvs, errs);
+  errs.push_back(new ConstZeroError);
+
+  SparseQrLinearSystemSolver solver;
+  EXPECT_FALSE(solver.isAcceptConstantErrorTerms());
+  solver.setAcceptConstantErrorTerms(true);
+  EXPECT_NO_THROW(solver.initMatrixStructure(dvs, errs, false));
+  EXPECT_NO_THROW(solver.buildSystem(1, false));
+
+  solver.setAcceptConstantErrorTerms(false);
+  EXPECT_ANY_THROW(solver.initMatrixStructure(dvs, errs, false));
+  deleteSystem(dvs, errs);
+}


### PR DESCRIPTION
If enabled the system builder must not throw on constant error terms (:= not depending on any active design variable)
That doesn't mean all linear system solvers throw on constant error terms when this is disabled (default as before). In fact only the sparse solver do that at the moment.