### PR TITLE
Feature/exports for oomact

### DIFF
--- a/aslam_backend_python/src/BackendExpressions.cpp
+++ b/aslam_backend_python/src/BackendExpressions.cpp
@@ -160,6 +160,7 @@ void exportBackendExpressions()
       .def("toHomogeneousExpression", &EuclideanPoint::toHomogeneousExpression)
       .def("toEuclidean", &EuclideanPoint::toEuclidean, return_value_policy<copy_const_reference>())
       .def("getDesignVariables", &getDesignVariables<EuclideanPoint>)
+      .def("set", &EuclideanPoint::set)
      ;
 
   class_<HomogeneousPoint, boost::shared_ptr<HomogeneousPoint>, bases<DesignVariable> >("HomogeneousPointDv", init<const Eigen::Vector4d>())

--- a/aslam_backend_python/src/BackendExpressions.cpp
+++ b/aslam_backend_python/src/BackendExpressions.cpp
@@ -153,6 +153,7 @@ void exportBackendExpressions()
     .def("toExpression", &RotationQuaternion::toExpression)
     .def("toRotationMatrix", &RotationQuaternion::toRotationMatrix)
     .def("getDesignVariables", &getDesignVariables<RotationQuaternion>)
+    .def("set", &RotationQuaternion::set)
     ;
 
   class_<EuclideanPoint, boost::shared_ptr<EuclideanPoint>, bases<DesignVariable> >("EuclideanPointDv", init<const Eigen::Vector3d>())


### PR DESCRIPTION
exports set function of rotationquaternion and euclideanpoint, which is required in oomact_python